### PR TITLE
feat: add REST endpoints for users, rooms and messages

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -36,6 +36,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
+ "axum-macros",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -79,6 +80,17 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1111,7 +1123,6 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "serde",
- "serde_json",
  "sqlx",
  "tokio",
 ]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2024"
 
 [dependencies]
 tokio = { version = "1", features = ["full"] }
-axum = "0.8"
+axum = { version = "0.8", features = ["macros"] }
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite"] }
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"

--- a/server/src/handlers/message.rs
+++ b/server/src/handlers/message.rs
@@ -1,0 +1,33 @@
+use axum::{extract::{Json, State, Path}, response::IntoResponse, http::StatusCode};
+use sqlx::SqlitePool;
+use crate::handlers::CreateMessage;
+use crate::models::message::Message;
+
+pub async fn create_message(State(pool): State<SqlitePool>, Path(room_id): Path<i64>, Json(message): Json<CreateMessage>) -> Result<impl IntoResponse, StatusCode> {
+    let mut conn = pool.acquire().await.map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    sqlx::query("INSERT INTO messages (message_type, sender, room, timestamp, content) VALUES (?, ?, ?, ?, ?)")
+        .bind("Text")                // Message Type texts are the only ones hitting the endpoint. Any system type would be auto generated hopefully. Correct me if am wrong
+        .bind(message.sender_id)
+        .bind(room_id)
+        .bind(0)
+        .bind(message.content)
+        .execute(&mut *conn)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    Ok(StatusCode::CREATED)
+}
+
+pub async fn get_messages(State(pool): State<SqlitePool>, Path(room_id): Path<i64>) -> Result<impl IntoResponse, StatusCode> {
+    let mut conn = pool.acquire().await.map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let messages = sqlx::query_as::<_, Message>("SELECT * FROM messages WHERE room = ?")
+        .bind(room_id)
+        .fetch_all(&mut *conn)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    Ok(Json(messages))
+
+}

--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -1,0 +1,25 @@
+use serde::Deserialize;
+
+pub mod user;
+pub mod room;
+pub mod message;
+
+#[derive(Deserialize)]
+pub struct CreateUser {
+    pub username: String,
+    pub password: String,
+    pub email: String,
+}
+
+#[derive(Deserialize)]
+pub struct CreateRoom {
+    pub name: String,
+    pub description: String,
+    pub owner_id: i64,
+}
+
+#[derive(Deserialize)]
+pub struct CreateMessage {
+    pub content: String,
+    pub sender_id: i64,
+}

--- a/server/src/handlers/room.rs
+++ b/server/src/handlers/room.rs
@@ -1,0 +1,18 @@
+use axum::{extract::{Json, State}, response::IntoResponse, http::StatusCode};
+use sqlx::SqlitePool;
+use crate::handlers::CreateRoom;
+
+pub async fn create_room(State(pool): State<SqlitePool>, Json(room): Json<CreateRoom>) -> Result<impl IntoResponse, StatusCode> {
+    let mut conn = pool.acquire().await.map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    sqlx::query("INSERT INTO rooms (name, description, created_by, created_at) VALUES (?, ?, ?, ?)")
+        .bind(room.name)
+        .bind(room.description)
+        .bind(room.owner_id)
+        .bind(0)
+        .execute(&mut *conn)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    Ok(StatusCode::CREATED)
+}

--- a/server/src/handlers/user.rs
+++ b/server/src/handlers/user.rs
@@ -1,0 +1,18 @@
+use axum::{extract::{Json, State}, response::IntoResponse, http::StatusCode};
+use sqlx::SqlitePool;
+use crate::handlers::CreateUser;
+
+pub async fn create_user(State(pool): State<SqlitePool>, Json(user): Json<CreateUser>) -> Result<impl IntoResponse, StatusCode> {
+    let mut conn = pool.acquire().await.map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    sqlx::query("INSERT INTO users (username, password_hash, email, created_at) VALUES (?, ?, ?, ?)")
+        .bind(user.username)
+        .bind(user.password)
+        .bind(user.email)
+        .bind(0)
+        .execute(&mut *conn)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    Ok(StatusCode::CREATED)
+}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,7 +1,22 @@
 mod models;
 mod db;
+mod handlers;
+
+use tokio::net::TcpListener;
+use axum::{Router, routing::{post, get}};
+use crate::handlers::{message::{create_message, get_messages},
+                      room::create_room,
+                      user::create_user};
 
 #[tokio::main]
 async fn main() {
-    let _pool = db::establish_db_connection("sqlite:bubblz.db?mode=rwc", "schema.sql").await.expect("Failed to establish DB connection with bubblz.db");
+    let pool = db::establish_db_connection("sqlite:bubblz.db?mode=rwc", "schema.sql").await.expect("Failed to establish DB connection with bubblz.db");
+    let router = Router::new()
+        .route("/users", post(create_user))
+        .route("/rooms", post(create_room))
+        .route("/rooms/{id}/messages", get(get_messages).post(create_message))
+        .with_state(pool);
+
+    let listener = TcpListener::bind("0.0.0.0:3000").await.expect("Failed to bind to port 3000");
+    axum::serve(listener, router).await.expect("Failed to run server");
 }

--- a/server/src/models/message.rs
+++ b/server/src/models/message.rs
@@ -1,10 +1,13 @@
-#[derive(Debug)]
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Serialize, Deserialize, sqlx::Type)]
+#[sqlx(type_name = "TEXT", rename_all = "PascalCase")]
 pub enum MessageType {
     System,
     Text,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize, sqlx::FromRow)]
 pub struct Message {
     pub id: i64,
     pub message_type: MessageType,

--- a/server/src/models/room.rs
+++ b/server/src/models/room.rs
@@ -8,13 +8,13 @@ pub struct Room {
 }
 
 impl Room {
-    pub fn new(id: i64, name: String, description: String, created_by: i64) -> Self {
+    pub fn new(id: i64, name: String, description: String, created_by: i64, created_at: i64) -> Self {
         Room {
             id,
             name,
             description,
             created_by,
-            created_at: 0,
+            created_at,
         }
     }
 

--- a/server/src/models/user.rs
+++ b/server/src/models/user.rs
@@ -1,4 +1,6 @@
-#[derive(Debug)]
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct User {
     pub id: i64,
     pub username: String,


### PR DESCRIPTION
This PR implements the four core REST endpoints for Bubblz:

- `POST /users` — create a new user
- `POST /rooms` — create a new room
- `POST /rooms/{id}/messages` — send a message to a room
- `GET /rooms/{id}/messages` — fetch all messages in a room

Handlers are organised into `handlers/user.rs`, `handlers/room.rs` and `handlers/message.rs`. Request body structs (`CreateUser`, `CreateRoom`, `CreateMessage`) live in `handlers/mod.rs`. Each handler acquires a connection from the SQLite pool, runs a parameterised sqlx query, and maps errors to appropriate HTTP status codes.

`Serialize`, `Deserialize` and `sqlx::FromRow` derives were added to all models to support JSON responses and database row mapping. `MessageType` additionally derives `sqlx::Type` to handle enum serialization to and from SQLite TEXT columns.

The axum router is wired up in `main.rs` with the database pool passed as shared state via `.with_state(pool)`.