### PR TITLE
chore: add github actions ci workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+    paths: ["server/**"]
+  pull_request:
+    branches: [main]
+    paths: ["server/**"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: server
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo
+            server/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('server/Cargo.lock') }}
+
+      - name: Build
+        run: cargo build
+
+      - name: Test
+        run: cargo test


### PR DESCRIPTION
Adds a GitHub Actions CI workflow that automatically runs on every push and pull request to `main` that touches files under `server/`.

The workflow runs on `ubuntu-latest` and performs the following steps:

- Checks out the repository
- Installs the stable Rust toolchain
- Caches Cargo dependencies keyed on `Cargo.lock` to speed up subsequent runs
- Runs `cargo build` to verify the project compiles
- Runs `cargo test` to verify all tests pass

Cross-platform builds (Windows, macOS) are intentionally excluded — the server is designed to run in a Linux Docker container, so Ubuntu is the only relevant target. Client-side cross-platform builds will be added in Phase 3.