### PR TITLE
chore: create issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,42 @@
+---
+name: Bug Report
+about: Report a technical bug or unexpected behaviour
+labels: bug
+assignees: Dheeps02
+---
+
+## Description
+<!-- What is happening? What did you expect to happen? -->
+
+## Steps to reproduce
+1. 
+2. 
+3. 
+
+## Expected behaviour
+<!-- What should have happened -->
+
+## Actual behaviour
+<!-- What actually happened -->
+
+## Environment
+<!-- Rust version, OS, any relevant config -->
+- Rust version:
+- OS:
+
+## Logs / error output
+<!-- Paste any relevant error messages or stack traces -->
+
+## Related issue
+<!-- If this bug is blocking or related to another issue, link it here -->
+Blocked by / Related to #
+
+## Notes
+<!-- Any additional context, suspected cause, or potential fix -->
+```
+
+---
+
+Add this, commit it:
+```
+chore: add bug report template

--- a/.github/ISSUE_TEMPLATE/feature-issue.md
+++ b/.github/ISSUE_TEMPLATE/feature-issue.md
@@ -1,7 +1,7 @@
 ---
 name: Feature Issue
 about: Issues describing feature implementation and acts as a parent for sub issues
-title: "[Phase X]"
+title: "[Phase X]: "
 labels: feature
 assignees: Dheeps02
 

--- a/.github/ISSUE_TEMPLATE/feature-issue.md
+++ b/.github/ISSUE_TEMPLATE/feature-issue.md
@@ -1,0 +1,22 @@
+---
+name: Feature Issue
+about: Issues describing feature implementation and acts as a parent for sub issues
+title: "[Phase X]"
+labels: feature
+assignees: Dheeps02
+
+---
+
+## Summary
+<!-- One sentence describing what this issue delivers -->
+
+## Sub-issues
+<!-- List sub-issues here as they are created -->
+- [ ] 
+
+## Dependencies
+<!-- Issues that must be closed before this one can start -->
+Blocked by: #
+
+## Notes
+<!-- Any architectural decisions, open questions, or context -->

--- a/.github/ISSUE_TEMPLATE/sub-issue.md
+++ b/.github/ISSUE_TEMPLATE/sub-issue.md
@@ -1,0 +1,22 @@
+---
+name: Sub-Issue
+about: Byte sized breakdown of a Parent Issue for easier implementation
+title: ''
+labels: ''
+assignees: Dheeps02
+
+---
+
+## What
+<!-- One sentence — what exactly needs to be built or done -->
+
+## Why
+<!-- Why is this needed? What does it unblock or enable? -->
+
+## Acceptance criteria
+<!-- How do you know this is done? -->
+- [ ] 
+
+## Parent issue
+<!-- Link to the parent issue this belongs to -->
+Part of #

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Summary
+<!-- What does this PR do? One or two sentences -->
+
+## Related issue
+Closes #
+
+## Changes
+<!-- Brief bullet list of what changed -->
+- 
+
+## Type of change
+- [ ] Feature
+- [ ] Bug fix
+- [ ] Chore
+- [ ] Documentation
+
+## Testing
+<!-- How did you verify this works? -->
+- [ ] cargo build passes
+- [ ] cargo test passes
+- [ ] Manually tested via curl / client
+
+## Notes
+<!-- Anything the reviewer should know — design decisions, known limitations, follow-up work -->


### PR DESCRIPTION
Add two issue templates to standardise how features and sub-issues are created across the project.

- Feature Issue template — covers summary, sub-issues checklist, dependencies and notes
- Sub-issue template — covers what, why, acceptance criteria and parent issue link

Closes #19